### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,8 @@ Contributions are welcome! If you'd like to contribute, please fork the reposito
 - **Documentation**: Help improve or translate documentation. Any form of documentation enhancement is appreciated.
 
 For major changes, please open an issue first to discuss what you would like to change. We're looking forward to your contributions!
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/esignaturescom-mcp-server-esignatures).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/esignaturescom-mcp-server-esignatures).